### PR TITLE
Add Nezha protocol message types

### DIFF
--- a/omnipaxos/Cargo.toml
+++ b/omnipaxos/Cargo.toml
@@ -24,6 +24,10 @@ lru = { version = "0.11.0", optional = true }
 num-traits = { version = "0.2.16", optional = true }
 linked_hash_set = { version = "0.1.4", optional = true }
 
+[dependencies.uuid]
+version = "1.21.0"
+features = ["v4", "serde"]
+
 [dev-dependencies]
 kompact = { git = "https://github.com/kompics/kompact", rev = "4fd1fdc", features = ["silent_logging"] }
 omnipaxos_storage = { path = "../omnipaxos_storage", features = ["persistent_storage"] }

--- a/omnipaxos/src/messages.rs
+++ b/omnipaxos/src/messages.rs
@@ -1,5 +1,5 @@
 use crate::{
-    messages::{ballot_leader_election::BLEMessage, sequence_paxos::PaxosMessage, nezha::NezhaMessage},
+    messages::{ballot_leader_election::BLEMessage, sequence_paxos::PaxosMessage},
     storage::Entry,
     util::NodeId,
 };
@@ -201,11 +201,10 @@ pub mod nezha {
     #[cfg(feature = "serde")]
     use serde::{Deserialize, Serialize};
 
-    /// TODO: probably nice to replace with Timestamp from clock_simulator oncen integrated?
+    /// Timestamp type used for Nezha messages, representing the time when a message is sent or a deadline for processing the message
     pub type Timestamp = u64;
-    /// TODO: replace with the requestId type from NezhaProxy once the prozy defines a requestId type?
-    /// then we could avoid having both client_id and request_id
-    pub type RequestId = u64; 
+    /// Unique identifier for client requests, used to track requests across the system and match replies to requests
+    pub type RequestId = uuid::Uuid;
 
     /// Request sent by a client to the proxy to propose an entry for replication
     #[derive(Clone, Debug)]


### PR DESCRIPTION
I initially added a Nezha to the shared Message<T> enum so everything could go through the same transport layer. But after thinking more about the layering, I wasn’t sure that was correct. If we keep it inside the Message<T>... then OmniPaxos becomes aware of prozy-level concepts.

Would be awesome to get your thoughts on whether we want the separation and we can then discuss it further!