### PR TITLE
Add skeleton for fast path

### DIFF
--- a/omnipaxos/src/messages.rs
+++ b/omnipaxos/src/messages.rs
@@ -183,14 +183,16 @@ pub mod sequence_paxos {
 
     impl<T: Entry> PartialEq for PrepareWithDeadline<T> {
         fn eq(&self, other: &Self) -> bool {
-            self.deadline == other.deadline
+            self.request_id == other.request_id && self.deadline == other.deadline
         }
     }
 
-    // Reverse ordering so BinaryHeap (which is a max-heap) pops the smallest/earliest deadline first
     impl<T: Entry> Ord for PrepareWithDeadline<T> {
         fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-            other.deadline.cmp(&self.deadline)
+            // compare first by deadline, breaking ties by request_id when required
+            self.deadline
+                .cmp(&other.deadline)
+                .then_with(|| self.request_id.cmp(&other.request_id))
         }
     }
 

--- a/omnipaxos/src/sequence_paxos/mod.rs
+++ b/omnipaxos/src/sequence_paxos/mod.rs
@@ -15,6 +15,7 @@ use crate::{
 #[cfg(feature = "logging")]
 use slog::{debug, info, trace, warn, Logger};
 use std::{
+    cmp::Reverse,
     collections::{BinaryHeap, HashMap},
     fmt::Debug,
     vec,
@@ -44,7 +45,7 @@ where
     current_seq_num: SequenceNumber,
     cached_promise_message: Option<Promise<T>>,
     // Nezha attributes
-    early_buffer: BinaryHeap<PrepareWithDeadline<T>>,
+    early_buffer: BinaryHeap<Reverse<PrepareWithDeadline<T>>>,
     last_released_deadline: u64, // TODO: use correct type for clock simulator
     late_buffer: HashMap<RequestId, PrepareWithDeadline<T>>,
     sync_point: usize,
@@ -329,8 +330,8 @@ where
         prep: PrepareWithDeadline<T>,
         from: NodeId,
     ) {
-        if prep.deadline < self.last_released_deadline {
-            self.early_buffer.push(prep);
+        if prep.deadline > self.last_released_deadline {
+            self.early_buffer.push(Reverse(prep));
         } else {
             self.late_buffer.insert(prep.request_id, prep);
         }


### PR DESCRIPTION
Adds basic data structures needed to work on fast path.

We had discussed moving message types to SequencePaxos, but as that wasn't in preceeding PR I only wanted to make minimal changes necessary here.
EDIT: I just moved the non-client messages over.