### PR TITLE
Fix: use check_valid_ballot for incoming messages on follower

### DIFF
--- a/omnipaxos/src/sequence_paxos/follower.rs
+++ b/omnipaxos/src/sequence_paxos/follower.rs
@@ -294,7 +294,7 @@ where
             #[cfg(feature = "logging")]
             info!(
                 self.logger,
-                "Ignoring LogModifications message from ballot: {:?}, current balot: {:?}",
+                "Ignoring LogModifications message from ballot: {:?}, current ballot: {:?}",
                 lm.n,
                 self.internal_storage.get_promise()
             );
@@ -411,7 +411,7 @@ where
             #[cfg(feature = "logging")]
             info!(
                 self.logger,
-                "Ignoring CommitStatus message from ballot: {:?}, current balot: {:?}",
+                "Ignoring CommitStatus message from ballot: {:?}, current ballot: {:?}",
                 cs.n,
                 self.internal_storage.get_promise()
             );

--- a/omnipaxos/src/sequence_paxos/leader.rs
+++ b/omnipaxos/src/sequence_paxos/leader.rs
@@ -461,7 +461,7 @@ where
     pub(crate) fn handle_log_status(&mut self, log_status: LogStatus, from: NodeId) {
         if self.state != (Role::Leader, Phase::Accept) {
             #[cfg(feature = "logging")]
-            info!(self.logger, "Not handling LogStatus message",);
+            info!(self.logger, "Not handling LogStatus message");
             return;
         }
         // If message belongs to wrong ballot then ignore it


### PR DESCRIPTION
- Fix to use `check_valid_ballot` function for incoming messages on followers. This is what is done in other SequencePaxos follower message handlers.

- minor fix to not handle `LogStatus` messages on leader if leader is not in Accept phase.